### PR TITLE
feat: allow console appender to target stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,18 @@ Removing `logex` is as simple as removing `Logger.logFn` and deleting initialzat
 `logex` comes with two built-in appenders:
 
 - **Writer Appender**: A generic threadsafe appender that writes to an underlying `AnyWriter`
-- **Console Appender**: Logs to `stderr`, works the same as the default `logFn` from `std.log`
+- **Console Appender**: Logs to a configurable stream (defaults to `stderr`) and works the same as the default `logFn` from `std.log`
 - **File Appender**: Logs to file
+
+Switch the console output to `stdout` by setting the `stream` option:
+
+```zig
+const ConsoleStdout = logex.appenders.Console(.debug, .{
+    .stream = .stdout,
+});
+```
+
+Note: Only the stderr stream integrates with `std.Progress`'s locking; stdout is intended for simple printing.
 
 ### Creating Custom Appenders
 


### PR DESCRIPTION
Allow the console appender to write to stdout by adding a stream option, adjust locking to stay compatible with std.Progress on stderr, update docs, and cover the new path with a basic test.

Mentioned in https://github.com/ross-weir/logex/issues/14.