### PR TITLE
Remove generic writer for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ Removing `logex` is as simple as removing `Logger.logFn` and deleting initialzat
 
 `logex` comes with two built-in appenders:
 
-- **Writer Appender**: A generic threadsafe appender that writes to an underlying `AnyWriter`
 - **Console Appender**: Logs to `stderr`, works the same as the default `logFn` from `std.log`
 - **File Appender**: Logs to file
 

--- a/src/appenders.zig
+++ b/src/appenders.zig
@@ -8,40 +8,8 @@ const Context = root.Context;
 pub const Options = struct {
     /// The format to use when writting log lines.
     format: format.Format = .text,
+    buffer_size: usize = 4096,
 };
-
-/// A generic writer based appender.
-/// Writes logs to the provided `Writer` type.
-/// Uses a mutex internally to provide thread-safety when performing writes.
-pub fn Writer(
-    comptime level: std.log.Level,
-    comptime opts: Options,
-) type {
-    return struct {
-        const Self = @This();
-
-        writer: *std.Io.Writer,
-        mutex: std.Thread.Mutex = .{},
-
-        pub fn init(writer: *std.Io.Writer) Self {
-            return .{ .writer = writer };
-        }
-
-        pub fn log(
-            self: *Self,
-            context: *const Context,
-        ) !void {
-            self.mutex.lock();
-            defer self.mutex.unlock();
-            try opts.format.write(self.writer, context);
-            try self.writer.flush();
-        }
-
-        pub fn enabled(comptime log_level: std.log.Level) bool {
-            return @intFromEnum(log_level) <= @intFromEnum(level);
-        }
-    };
-}
 
 /// Console appender writes logs to stderr.
 /// Uses the `std.debug` stderr mutex so Console appender
@@ -52,7 +20,7 @@ pub fn Console(
 ) type {
     return struct {
         const Self = @This();
-        var buffer: [4096]u8 = undefined;
+        var buffer: [opts.buffer_size]u8 = undefined;
 
         pub const init: Self = .{};
 
@@ -64,8 +32,6 @@ pub fn Console(
             var stderr = &writer.interface;
 
             // we use this lock to be compitable with std.Progress
-            // because of this we can't use `Writer` appender as it has its own mutex
-            // and the std.Progress mutex isn't pub
             std.debug.lockStdErr();
             defer std.debug.unlockStdErr();
             nosuspend {
@@ -88,13 +54,10 @@ pub fn File(
 ) type {
     return struct {
         const Self = @This();
-        const Inner = Writer(level, opts);
+        var buffer: [opts.buffer_size]u8 = undefined;
 
-        // If buffer is a global we get a "General protection exception" error.
-        // Not sure why this is the case, probably doesnt matter.
-        buffer: [4096]u8 = undefined,
         file: std.fs.File,
-        inner: Inner,
+        mutex: std.Thread.Mutex = .{},
 
         /// Create a File appender that writes to the supplied file path.
         /// The file will be appended to if it already exists.
@@ -113,25 +76,25 @@ pub fn File(
         pub fn initFromFile(file: std.fs.File) !Self {
             try file.seekTo(try file.getEndPos());
 
-            var self: Self = .{
-                .file = file,
-                .inner = undefined,
-            };
-            var writer = file.writer(&self.buffer);
-            self.inner = Inner.init(&writer.interface);
-
-            return self;
+            return .{ .file = file };
         }
 
-        pub inline fn log(
+        pub fn log(
             self: *Self,
             context: *const Context,
         ) !void {
-            return self.inner.log(context);
+            var writer = self.file.writer(&buffer);
+            var interface = &writer.interface;
+
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            try opts.format.write(interface, context);
+            try interface.flush();
         }
 
         pub fn enabled(comptime log_level: std.log.Level) bool {
-            return Inner.enabled(log_level);
+            return @intFromEnum(log_level) <= @intFromEnum(level);
         }
     };
 }


### PR DESCRIPTION
Removing this until it's needed

Current implementation was causing a segfault, I think because the writer interface that was being passed to `Writer` was going out of scope/getting cleaned up